### PR TITLE
fix: disable debug mode in production environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -289,4 +289,4 @@ os.makedirs(os.path.dirname(ANNOUNCEMENTS_FILE), exist_ok=True)
 if __name__ == "__main__":
     # For local development
     port = int(os.environ.get("PORT", 5000))
-    app.run(host='0.0.0.0', port=port, debug=True)
+    app.run(host='0.0.0.0', port=port, debug=False)


### PR DESCRIPTION
Sets the debug mode to False when running the application. This change 
enhances security and performance by preventing the exposure of 
detailed error messages in a production setting.