### PR TITLE
fix: update hackathon start time in countdown script

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -124,7 +124,7 @@
 {% block scripts %}
 <script>
     // Countdown Timer
-    const hackathonDate = new Date('March 13, 2025 09:00:00').getTime();
+    const hackathonDate = new Date('March 13, 2025 10:00:00').getTime();
     
     function updateCountdown() {
         const now = new Date().getTime();


### PR DESCRIPTION
Adjusts the hackathon start time in the countdown script from 09:00 
to 10:00 to reflect the correct event schedule. This ensures that 
participants have the accurate timing for the event.