### PR TITLE
fix: correct typo in announcements.json title

### DIFF
--- a/data/announcements.json
+++ b/data/announcements.json
@@ -34,7 +34,7 @@
         "author": "KARE OSS Team",
         "links": [
             {
-                "title": "Selecet problem statements",
+                "title": "Select problem statements",
                 "url": "https://forms.gle/KMDZcxKMk7YxmSqW9"
             }
         ]


### PR DESCRIPTION
Corrects the spelling of "Selecet" to "Select" in the 
announcements.json file to improve clarity and 
maintain professionalism in the content.